### PR TITLE
[Fix] remove false positive in object-without-signer and change Id of transfer-object-within-resource-group

### DIFF
--- a/rules/move_on_aptos/objects/security/object-without-signer.yaml
+++ b/rules/move_on_aptos/objects/security/object-without-signer.yaml
@@ -42,6 +42,10 @@ rules:
           fun $ENTRYPOINT(...): ... {
             abort $_
           }
+      - metavariable-pattern:
+          metavariable: $TYPE
+          patterns:
+            - pattern-not: aptos_framework::fungible_asset::Metadata
       # Tests are exempted
       - pattern-not: |
           #[test]

--- a/rules/move_on_aptos/objects/security/transfer-object-within-resource-group.yaml
+++ b/rules/move_on_aptos/objects/security/transfer-object-within-resource-group.yaml
@@ -1,5 +1,5 @@
 rules:
-  - id: objects-in-group-stored-without-account
+  - id: transfer-object-within-resource-group
     languages: [move_on_aptos]
     message: >-
       When different objects are stored under the same resource group in the same account, moving one object moves them all.


### PR DESCRIPTION
- Updated `object-without-signer.yaml` to add a new `metavariable-pattern` excluding `aptos_framework::fungible_asset::Metadata`.
- Renamed the rule ID in `transfer-object-within-resource-group.yaml` for better clarity.